### PR TITLE
Topic model top words

### DIFF
--- a/newsviz/pipeline.py
+++ b/newsviz/pipeline.py
@@ -108,6 +108,7 @@ class TopicPredictorTask(luigi.Task):
         self.input_path_c = self.config["classifier"]["output_path"]
         self.input_path_l = self.config["preprocessor"]["output_path"]
         self.output_path = self.config["topic"]["output_path"]
+        self.output_path_tw = os.path.join(self.output_path, "topwords")
         self.model_path = self.config["topic"]["model_path"]
         # TODO: move model params to the model wrapper script
         self.dict_path = self.config["topic"]["dict_path"]
@@ -119,6 +120,8 @@ class TopicPredictorTask(luigi.Task):
         return RubricClassifierTask(conf=self.conf)
 
     def run(self):
+        if not os.path.exists(self.output_path_tw):
+            os.mkdir(self.output_path_tw)
         for fname in self.fnames:
             readpath_c = os.path.join(self.input_path_c, fname)
             readpath_l = os.path.join(self.input_path_l, fname)
@@ -141,7 +144,7 @@ class TopicPredictorTask(luigi.Task):
                     left_index=True,
                     right_index=True,
                 )
-
+                tm.save_top_words(os.path.join(self.output_path_tw, f"tw_{cl}.json"))
                 result.to_csv(writepath, compression="gzip", index=False)
 
     def output(self):

--- a/newsviz/pipeline.py
+++ b/newsviz/pipeline.py
@@ -108,7 +108,6 @@ class TopicPredictorTask(luigi.Task):
         self.input_path_c = self.config["classifier"]["output_path"]
         self.input_path_l = self.config["preprocessor"]["output_path"]
         self.output_path = self.config["topic"]["output_path"]
-        self.output_path_tw = os.path.join(self.output_path, "topwords")
         self.model_path = self.config["topic"]["model_path"]
         # TODO: move model params to the model wrapper script
         self.dict_path = self.config["topic"]["dict_path"]
@@ -120,8 +119,7 @@ class TopicPredictorTask(luigi.Task):
         return RubricClassifierTask(conf=self.conf)
 
     def run(self):
-        if not os.path.exists(self.output_path_tw):
-            os.mkdir(self.output_path_tw)
+        os.makedirs(os.path.join(self.output_path, "topwords"), exist_ok=True)
         for fname in self.fnames:
             readpath_c = os.path.join(self.input_path_c, fname)
             readpath_l = os.path.join(self.input_path_l, fname)
@@ -144,7 +142,9 @@ class TopicPredictorTask(luigi.Task):
                     left_index=True,
                     right_index=True,
                 )
-                tm.save_top_words(os.path.join(self.output_path_tw, f"tw_{cl}.json"))
+                tm.save_top_words(
+                    os.path.join(self.output_path, "topwords", f"tw_{cl}.json")
+                )
                 result.to_csv(writepath, compression="gzip", index=False)
 
     def output(self):

--- a/newsviz/topic_model.py
+++ b/newsviz/topic_model.py
@@ -1,4 +1,5 @@
 import os
+import json
 
 import artm
 import numpy as np
@@ -142,10 +143,10 @@ class TopicModelWrapperARTM:
         """
         phi = self.get_phi()
         top_words_dict = dict()
-        for topic in phi.columns:
+        for topic in phi.columns.drop('word'):
             top_words = (phi.sort_values(
                 by=topic,
-                ascending=False)["word"].apply(lambda x: x[1]).values[:top])
+                ascending=False)["word"].values[:top])
             top_words_dict[topic] = list(top_words)
 
         json.dump(top_words_dict, open(path, "w"))


### PR DESCRIPTION
#4 
Проверил весь пайплайн на данных gateza (отсюда #3) и моделях [отсюда](https://drive.google.com/drive/folders/11KAPsKd5kfF2JvAGSWTQ6RHtLDeLH63-) 

1. `save_top_words` сначала отказался работать из-за строчки [`.apply(lambda x: x[1])`](https://github.com/newsviz/newsviz/blob/6880b5a04a49ffc2f3548cb7008c6cefe0f53d2f/newsviz/topic_model.py#L148), пришлось его немного поправить (тут стоит перепроверить, возможно, я что-то упустил и на других/новых датасетах (версии bigARTM?) это будет работать по-другому)
2. Сохранение топ-слов для каждого класса в директории `topwords` внутри `output_path`