### PR TITLE
Шаблонный пайплайн: Тематизатор

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,5 @@ data
 # data
 *.csv.gz
 *.bin
+# tm dicts
+models/**/*.txt

--- a/config/config.ini
+++ b/config/config.ini
@@ -19,12 +19,12 @@ ftransformer_path = ../models/classifier/gazeta_tfidf.bin
 
 [topic]
 ; where thematized files should be written
-output_path = ../data/tmed
+output_path = ../data/topic_model_ed
 ; should be prepared manually
 ; pretrained model path (saved with artm's model.save())
-model_path = ../data/artm/model
+model_path = ../models/topic_model
 ; dictionary path
-dict_path = ../data/artm/dicts/dict_gazeta.txt
+dict_path = ../models/topic_model
 
 [visualizer]
 ; where files for visualization are stored

--- a/newsviz/pipeline.py
+++ b/newsviz/pipeline.py
@@ -136,13 +136,16 @@ class TopicPredictorTask(luigi.Task):
             classes = data_c["rubric_preds"].unique()
             source_name = fname.split(".")[0]
             for cl in classes:
-                tm = topic_model.TopicModelWrapperARTM(self.output_path, source_name)
+                tm = topic_model.TopicModelWrapperARTM(self.output_path, source_name + "_" + str(cl))
                 mask = data_c["rubric_preds"] == cl
                 # TODO: add option to replace class label by class name
                 writepath = os.path.join(
                     self.output_path, source_name + str(cl) + ".csv.gz"
                 )
-                tm.load_model(self.model_path + str(cl) + ".bin", self.dict_path)
+                tm.load_model(
+                    os.path.join(self.model_path, f"tm_{source_name}_{cl}.bin"),
+                    os.path.join(self.dict_path, f"dictionary_tm_{source_name}_{cl}.txt")
+                )
                 tm.prepare_data(data_l[mask]["lemmatized"].values)
                 theta = tm.transform()
                 result = theta.merge(
@@ -151,7 +154,7 @@ class TopicPredictorTask(luigi.Task):
                     right_index=True,
                 )
                 tm.save_top_words(
-                    os.path.join(self.output_path, "topwords", f"tw_{cl}.json")
+                    os.path.join(self.output_path, "topwords", f"tw_{source_name}_{cl}.json")
                 )
                 result.to_csv(writepath, compression="gzip", index=False)
 

--- a/templates/make_tm.py
+++ b/templates/make_tm.py
@@ -1,0 +1,24 @@
+import json
+from pathlib import Path
+
+import pandas as pd
+
+from newsviz.topic_model import TopicModelWrapperARTM
+
+
+DATASET_NAME = "gazeta"
+PATH = "data/topic_model_ed"
+MODEL_PATH = Path("models/topic_model")
+
+data = pd.read_csv(f"data/processed/{DATASET_NAME}.csv.gz", compression="gzip")
+classified = pd.read_csv(f"data/classified/{DATASET_NAME}.csv.gz", compression="gzip")
+
+classes = classified["rubric_preds"].unique()
+
+for cl in classes:
+    mask = classified["rubric_preds"] == cl
+    tm = TopicModelWrapperARTM(PATH, DATASET_NAME + "_" + str(cl))
+    tm.prepare_data(data[mask]["lemmatized"].values)
+    tm.init_model()
+    tm.fit()
+    tm.save_model(str(MODEL_PATH / f"tm_{DATASET_NAME}_{cl}.bin"))


### PR DESCRIPTION
closes #8 

1. Ожидает данные в `data/processed/` и `data/classified/` (в соответсвии с #3 )
2. Запуск: `PYTHONPATH='.' python templates/make_tm.py`
3. На выходе N моделей и N словарей в директории `models/topic_model`, где N это количество рубрик (классов) из шага классификации. 
4. Названия модели: `tm_{DATASET_NAME}_{CLASS}.bin`, словаря: `dictionary_tm_{DATASET_NAME}_{CLASS}.txt`
5. Немного поправил `TopicPredictorTask` и config, чтобы читать модели/словари из соответсвующих директорий, а также добавлять имя датасета при сохранении topwords
