### PR TITLE
#56 add link to project description page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,6 +139,7 @@ cython_debug/
 
 # VSCode
 .vscode
+.devcontainer
 
 # Data files
 data

--- a/newsviz/visualizer/app.py
+++ b/newsviz/visualizer/app.py
@@ -155,6 +155,8 @@ app.layout = html.Div(
     children=[
         # Page heading
         html.H1(children="NewsViz Project"),
+        html.Div([html.A("О проекте", href="https://newsviz.github.io/", target="_blank")]),
+        html.H2(children="Темы в текстах"),
         # left panel and main plot
         html.Div(children=[left_panel, fig_div]),
         # Table with top words for chosen topics


### PR DESCRIPTION
После добавления ссылки она оказалась приклеена к основному блоку. 
Лучше смотрится, если добавить к основной визуализации заголовок. Добавила заголовок "Темы в текстах".