### PR TITLE
Подключение sqlite и sqlalchemy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,7 +141,12 @@ cython_debug/
 .vscode
 
 # Data files
-data
+data/classified
+data/processed
+data/raw
+data/ready2viz
+data/topic_model_ed
+
 # data
 *.csv.gz
 *.bin
@@ -149,3 +154,5 @@ data
 models/**/*.txt
 bigartm.*
 
+#ide
+.idea

--- a/database/db_create.py
+++ b/database/db_create.py
@@ -1,0 +1,22 @@
+"""
+Скрипт создает базу данных на локальной машине пользователя,
+которые инициировал скрипт. Данный файл должен лежать в той папке,
+где планируется лежать база данных
+"""
+from sqlalchemy import create_engine
+# в models.py лежит структура БД, которую надо создавать, поэтому импортируем ее
+import models
+import os
+
+DB_NAME = 'newsviz.sqlite'
+
+# Инициируем нашу базу данных с именем DB_NAME
+# Если нужно создать базу данных в оперативной памяти, а не на диске, то
+# вместо {DB_NAME} указываем :memory:, т.е. вот так engine наш выглядит будет
+# так: sqlite:///:memory:
+engine = create_engine(f'sqlite:///{DB_NAME}', echo=True)
+if os.path.exists(DB_NAME):
+    print('База данных уже существует')
+else:
+    models.Base.metadata.create_all(engine)
+    print('База данных успешно создана')

--- a/database/example_sqlalchemy.ipynb
+++ b/database/example_sqlalchemy.ipynb
@@ -1,0 +1,306 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Краткий туториал по работе с SQLAlchemy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Подгрузим нужные библиотеки\n",
+    "from sqlalchemy import create_engine\n",
+    "from sqlalchemy.orm import sessionmaker\n",
+    "import datetime\n",
+    "\n",
+    "from models import News\n",
+    "import uuid"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Инициируем нашу БД. Вообще тут грубый вариант, правильный вариант нужно сделать, инициализацию в отдельном модуле, классе"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "engine = create_engine('sqlite:///newsviz.sqlite', echo=True)\n",
+    "Session = sessionmaker(bind=engine)\n",
+    "Session = sessionmaker()\n",
+    "Session.configure(bind=engine)\n",
+    "# Открыли сессию для записи\n",
+    "session = Session()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Пример вставки одной записи. Используется функция **.add**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "news = News(id=str(uuid.uuid4()), date='2020-12-07', topic='sport', text=\"{'москва': 1, '30': 1, 'апрель': 2}\", created_at=datetime.date.today(), updated_at=datetime.date.today())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "session.add(news)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Пример множественной ставки нескольких записей с помощью функцию **add_all**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "session.add_all([\n",
+    "    News(id=str(uuid.uuid4()), date='2020-12-07', topic='sport', text=\"{'москва': 1, '30': 1, 'апрель': 2}\", created_at=datetime.date.today(), updated_at=datetime.date.today()),\n",
+    "    News(id=str(uuid.uuid4()), date='2020-12-06', topic='sport', text=\"{'москва': 1, '30': 13, 'апрель': 2}\", created_at=datetime.date.today(), updated_at=datetime.date.today()),\n",
+    "    News(id=str(uuid.uuid4()), date='2020-12-05', topic='moscow', text=\"{'москва': 1, '30': 1, 'апрель': 2}\", created_at=datetime.date.today(), updated_at=datetime.date.today())])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2020-12-15 09:47:46,000 INFO sqlalchemy.engine.base.Engine SELECT CAST('test plain returns' AS VARCHAR(60)) AS anon_1\n",
+      "2020-12-15 09:47:46,003 INFO sqlalchemy.engine.base.Engine ()\n",
+      "2020-12-15 09:47:46,004 INFO sqlalchemy.engine.base.Engine SELECT CAST('test unicode returns' AS VARCHAR(60)) AS anon_1\n",
+      "2020-12-15 09:47:46,005 INFO sqlalchemy.engine.base.Engine ()\n",
+      "2020-12-15 09:47:46,007 INFO sqlalchemy.engine.base.Engine BEGIN (implicit)\n",
+      "2020-12-15 09:47:46,009 INFO sqlalchemy.engine.base.Engine INSERT INTO news (created_at, updated_at, id, date, topic, text) VALUES (?, ?, ?, ?, ?, ?)\n",
+      "2020-12-15 09:47:46,010 INFO sqlalchemy.engine.base.Engine (('2020-12-15 00:00:00.000000', '2020-12-15 00:00:00.000000', '603f7adc-e8c6-4f68-aeec-8af560b40304', '2020-12-07', 'sport', \"{'москва': 1, '30': 1, 'апрель': 2}\"), ('2020-12-15 00:00:00.000000', '2020-12-15 00:00:00.000000', '6a89c47c-2715-4191-a2aa-3e3c7c21ec7b', '2020-12-07', 'sport', \"{'москва': 1, '30': 1, 'апрель': 2}\"), ('2020-12-15 00:00:00.000000', '2020-12-15 00:00:00.000000', '0ce67f0a-f58a-43ad-8f44-4162e50f83a5', '2020-12-06', 'sport', \"{'москва': 1, '30': 13, 'апрель': 2}\"), ('2020-12-15 00:00:00.000000', '2020-12-15 00:00:00.000000', '90bdb109-fd0f-4013-8edb-39036cd99f8a', '2020-12-05', 'moscow', \"{'москва': 1, '30': 1, 'апрель': 2}\"))\n",
+      "2020-12-15 09:47:46,012 INFO sqlalchemy.engine.base.Engine COMMIT\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Закрываем запись в базу. Именно эта команда дает старт окончании транзакции, после ее выполнения данные запишуться\n",
+    "# в базу данных\n",
+    "session.commit()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2020-12-15 09:47:51,670 INFO sqlalchemy.engine.base.Engine BEGIN (implicit)\n",
+      "2020-12-15 09:47:51,672 INFO sqlalchemy.engine.base.Engine SELECT news.created_at AS news_created_at, news.updated_at AS news_updated_at, news.id AS news_id, news.date AS news_date, news.topic AS news_topic, news.text AS news_text \n",
+      "FROM news ORDER BY news.id\n",
+      "2020-12-15 09:47:51,672 INFO sqlalchemy.engine.base.Engine ()\n",
+      "0ce67f0a-f58a-43ad-8f44-4162e50f83a5 2020-12-06 sport {'москва': 1, '30': 13, 'апрель': 2}\n",
+      "603f7adc-e8c6-4f68-aeec-8af560b40304 2020-12-07 sport {'москва': 1, '30': 1, 'апрель': 2}\n",
+      "6a89c47c-2715-4191-a2aa-3e3c7c21ec7b 2020-12-07 sport {'москва': 1, '30': 1, 'апрель': 2}\n",
+      "90bdb109-fd0f-4013-8edb-39036cd99f8a 2020-12-05 moscow {'москва': 1, '30': 1, 'апрель': 2}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Пример вывода данных из базы\n",
+    "for instance in session.query(News).order_by(News.id):\n",
+    "    print(instance.id, instance.date, instance.topic, instance.text)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2020-12-15 09:47:55,917 INFO sqlalchemy.engine.base.Engine SELECT news.created_at AS news_created_at, news.updated_at AS news_updated_at, news.id AS news_id, news.date AS news_date, news.topic AS news_topic, news.text AS news_text \n",
+      "FROM news\n",
+      "2020-12-15 09:47:55,918 INFO sqlalchemy.engine.base.Engine ()\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Еще один пример вывода\n",
+    "news = session.query(News).all()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[<News(date='2020-12-07', topic='sport', text='{'москва': 1, '30': 1, 'апрель': 2}')>, <News(date='2020-12-07', topic='sport', text='{'москва': 1, '30': 1, 'апрель': 2}')>, <News(date='2020-12-06', topic='sport', text='{'москва': 1, '30': 13, 'апрель': 2}')>, <News(date='2020-12-05', topic='moscow', text='{'москва': 1, '30': 1, 'апрель': 2}')>]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(news)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "603f7adc-e8c6-4f68-aeec-8af560b40304 sport 2020-12-07 {'москва': 1, '30': 1, 'апрель': 2}\n",
+      "6a89c47c-2715-4191-a2aa-3e3c7c21ec7b sport 2020-12-07 {'москва': 1, '30': 1, 'апрель': 2}\n",
+      "0ce67f0a-f58a-43ad-8f44-4162e50f83a5 sport 2020-12-06 {'москва': 1, '30': 13, 'апрель': 2}\n",
+      "90bdb109-fd0f-4013-8edb-39036cd99f8a moscow 2020-12-05 {'москва': 1, '30': 1, 'апрель': 2}\n"
+     ]
+    }
+   ],
+   "source": [
+    "for item in news:\n",
+    "    print(item.id, item.topic, item.date, item.text)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/database/models.py
+++ b/database/models.py
@@ -1,0 +1,36 @@
+"""
+В данном файле описывается структура БД проекта, в данном файле
+должно находится описание всех таблиц базы данных.
+"""
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy import Column, String, TIMESTAMP
+from sqlalchemy.schema import FetchedValue
+
+Base = declarative_base()
+
+
+class BaseModel(Base):
+    """
+    Абстрактный класс, описывающий все поля общие для всех таблиц. От
+    него будут наследоваться остальные классы наших таблиц
+    """
+    __abstract__ = True
+
+    created_at = Column(TIMESTAMP, nullable=False, server_default=FetchedValue())
+    updated_at = Column(TIMESTAMP, nullable=False, server_default=FetchedValue(), server_onupdate=FetchedValue())
+
+    def __repr__(self):
+        return "<{0.__class__.__name__}(id={0.id!r})>".format(self)
+
+
+# Таблица News
+class News(BaseModel):
+    __tablename__ = 'news'
+    id = Column(String, primary_key=True)
+    date = Column(String)
+    topic = Column(String)
+    text = Column(String)
+
+    def __repr__(self):
+        return "<News(date='%s', topic='%s', text='%s')>" % (self.date, self.topic, self.text)
+


### PR DESCRIPTION
Подключена sqlalchemy. Сделана модель базы данных на sqlite, пока только с одной таблицой, добавлен скрипт развертки БД на локальной машине.
Изменения в директории **_database_**:
**models.py** - файл с описанием структуры БД, который требуется для sqlalchemy. Пока только одна таблица.
**db_create.py** - скрипт создания БД со структурой, описанной в models.py
**example_sqlalchemy.ipynb** - пример работы с sqlalchemy

Для того, чтобы развернуть БД:
1) Зайти в директорию `newsviz/database`
2) Запустить скрипт db_create:
```
python db_create.py
```
3) Все, база данных развернута и готова к использованию, можно открывать файл `example_sqlalchemy.ipynb` и смотреть примеры.